### PR TITLE
range can now be a simple string if there is only one adress in the range

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Here are a few usage examples & their output
 
 ### default ###
 ```javascript
-console.log(require('libnmap').nmap())
+console.log(require('node-libnmap').nmap())
 ```
 
 ### output ###
@@ -43,7 +43,7 @@ The discover method is the quickest method but is limited to finding local
 peers within the same CIDR per interface.
 
 ```javascript
-require('libnmap').nmap('discover', function(err, report){
+require('node-libnmap').nmap('discover', function(err, report){
   if (err) throw err
   console.log(report)
 })
@@ -67,19 +67,20 @@ require('libnmap').nmap('discover', function(err, report){
 ### scan ###
 A manually specified scan example using a single host (both IPv4 & IPv6 notation),
 a CIDR range a host range as well as a port range specification.
+If you have only one adress in your range list, you can give just a single string.
 
 ```javascript
 var opts = {
   range: ['10.0.2.128-255', '10.0.2.0/25', '192.168.0.0/17', '::ffff:192.168.2.15'],
-	ports: '21,22,80,443,3306,60000-65535'
+  // range: '127.0.0.1',
+  ports: '21,22,80,443,3306,60000-65535'
 }
-require('libnmap').nmap('scan', opts, function(err, report){
+require('node-libnmap').nmap('scan', opts, function(err, report){
   if (err) throw err
   report.forEach(function(item){
     console.log(item[0])
   })
 })
-
 ```
 
 ### output ###

--- a/lib/node-libnmap.js
+++ b/lib/node-libnmap.js
@@ -211,6 +211,8 @@ var version = 'v0.1.12'
      */
     verify: function(opts) {
       if (opts.range) {
+        if (/string/.test(typeof(opts.range)))
+          opts.range = [opts.range];
         if (!/array|object/.test(typeof(opts.range)))
           throw new Error('Range must be an array of host(s), examples:' +
             '[192.168.2.10 (single), 10.0.2.0/24 (CIDR), 10.0.10.5-20] (range)');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-libnmap",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Use nmap from node.js",
   "author": "Jason Gerfen <jason.gerfen@gmail.com>",
   "keywords": [

--- a/test/scan.js
+++ b/test/scan.js
@@ -30,7 +30,7 @@ describe('nmap', function(){
       this.timeout(timeout)
 
       var opts = {
-        range: ['localhost'],
+        range: 'localhost',
         ports: '1-1024'
       }
 


### PR DESCRIPTION
Range can now be a simple string if there is only one adress in the range list :

```javascript
var opts = {
  range: '127.0.0.1',
  ports: '21,22,80,443,3306,60000-65535'
}
require('node-libnmap').nmap('scan', opts, function(err, report){
  if (err) throw err
  report.forEach(function(item){
    console.log(item[0])
  })
})
```

I also fix the module name in the readme file.