### PR TITLE
Replace CLI Parser with XML Parser

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,0 @@
-MOCHA = ./node_modules/.bin/mocha
-REPORTER = list
-
-test:
-	@$(MOCHA) -R spec
-
-.PHONY: test

--- a/README.md
+++ b/README.md
@@ -2,33 +2,33 @@
 
 Access nmap using node.js
 
-## install ##
+## install
 To install `npm install node-libnmap`
 
-## tests ##
+## tests
 To test `npm test`
 
-## options ##
+## options
 * `threshold` - Defaults to processor core * 2, use `0` to disable
 * `nmap` - Path to nmap binary
 * `range` - Subnet range(s)
 * `ports` - Port range(s)
 * `callback` - A user defined callback function to retrieve & parse report
 
-## methods ##
+## methods
 * `init` - Returns version, license, help & nmap legal resources
 * `discover` - Performs auto-discovery of online hosts
 * `scan` - Performs scan given available range & optional port (not yet implemented)
 
-## examples ##
+## examples
 Here are a few usage examples & their output
 
-### default ###
+### default
 ```javascript
 console.log(require('libnmap').nmap())
 ```
 
-### output ###
+### output
 ```javascript
 > require('./').nmap()
 { name: 'node-libnmap',
@@ -39,111 +39,156 @@ console.log(require('libnmap').nmap())
   nmap: { legal: 'http://nmap.org/book/man-legal.html' } }
 ```
 
-### discover ###
+### discover
 The discover method is the quickest method but is limited to finding local
 peers within the same CIDR per interface.
 
 ```javascript
-require('libnmap').nmap('discover', function(err, report){
-  if (err) throw err
-  console.log(report)
-})
+require('libnmap').nmap('discover', function(err, reports) {
+  if (err) throw new Error(err);
+
+  console.log(reports);
+});
 ```
 
-### output ###
+### output
 ```javascript
-{ adapter: 'eth0',
-  properties:
-   { address: '10.0.2.15',
-     netmask: '255.255.255.0',
-     family: 'IPv4',
-     mac: '52:54:00:12:34:56',
-     internal: false,
-     cidr: '10.0.2.0/24',
-     hosts: 256,
-     range: { start: '10.0.2.1', end: '10.0.2.254' } },
-  neighbors: [ '10.0.2.2', '10.0.2.3', '10.0.2.15' ] }
+[{ 
+  adapter: 'eth0',
+  properties: { 
+    address: '10.0.2.15',
+    netmask: '255.255.255.0',
+    family: 'IPv4',
+    mac: '52:54:00:12:34:56',
+    internal: false,
+    cidr: '10.0.2.0/24',
+    hosts: 256,
+    range: { start: '10.0.2.1', end: '10.0.2.254' } 
+  },
+  neighbors: [ '10.0.2.2', '10.0.2.3', '10.0.2.15' ] 
+}]
 ```
 
-### scan ###
+### scan
 A manually specified scan example using a single host (both IPv4 & IPv6 notation),
 a CIDR range a host range as well as a port range specification.
 
 ```javascript
-var opts = {
+var options = {
   range: ['10.0.2.128-255', '10.0.2.0/25', '192.168.0.0/17', '::ffff:192.168.2.15'],
-	ports: '21,22,80,443,3306,60000-65535'
-}
-require('libnmap').nmap('scan', opts, function(err, report){
-  if (err) throw err
-  report.forEach(function(item){
-    console.log(item[0])
-  })
-})
+  ports: '80,443'
+};
 
+require('libnmap').nmap('scan', options, function(err, reports) {
+  if (err) throw new Error(err);
+
+  reports.forEach(function (report) {
+    console.log(report);
+  });
+});
 ```
 
-### output ###
+Check the [examples/nmap-scan.js](examples/nmap-scan.js) for a neat output.
+
+### output
+
+Flatten JSON representation of the nmap XML output Documentation
 
 ```javascript
-{ ip: '127.0.0.1',
-  hostname: 'localhost',
-  ports:
-   [ { port: '22',
-       state: 'open',
-       protocol: 'tcp',
-       owner: '',
-       service: 'ssh',
-       rpc: '',
-       version: '' } ] }
-{ ip: '10.0.2.15',
-  ports:
-   [ { port: '22',
-       state: 'open',
-       protocol: 'tcp',
-       owner: '',
-       service: 'ssh',
-       rpc: '',
-       version: '' } ] }
-{ ip: '192.168.2.15',
-  ports:
-   [ { port: '22',
-       state: 'open',
-       protocol: 'tcp',
-       owner: '',
-       service: 'ssh',
-       rpc: '',
-       version: '' } ] }
-{ ip: '192.168.2.2',
-  ports:
-   [ { port: '513',
-       state: 'open',
-       protocol: 'tcp',
-       owner: '',
-       service: 'login',
-       rpc: '',
-       version: '' },
-     { port: '514',
-       state: 'open',
-       protocol: 'tcp',
-       owner: '',
-       service: 'shell',
-       rpc: '',
-       version: '' },
-     { port: '631',
-       state: 'open',
-       protocol: 'tcp',
-       owner: '',
-       service: 'ipp',
-       rpc: '',
-       version: '' } ] }
+{
+    "$": {
+        "scanner": "nmap",
+        "args": "nmap -oX - -T5 -p80,443 10.12.20.97-128",
+        "start": "1438608336",
+        "startstr": "Mon Aug  3 15:25:36 2015",
+        "version": "6.47",
+        "xmloutputversion": "1.04"
+    },
+    "scaninfo": {
+        "type": "connect",
+        "protocol": "tcp",
+        "numservices": "2",
+        "services": "80,443"
+    },
+    "verbose": "0",
+    "debugging": "0",
+    "host": [{
+        "$": {
+            "starttime": "1438608336",
+            "endtime": "1438608336"
+        },
+        "status": {
+            "state": "up",
+            "reason": "conn-refused",
+            "reason_ttl": "0"
+        },
+        "address": {
+            "addr": "10.12.20.99",
+            "addrtype": "ipv4"
+        },
+        "hostnames": {
+            "name": "some-host-name",
+            "type": "PTR"
+        },
+        "ports": [{
+            "$": {
+                "protocol": "tcp",
+                "portid": "80"
+            },
+            "state": {
+                "state": "open",
+                "reason": "syn-ack",
+                "reason_ttl": "0"
+            },
+            "service": {
+                "name": "http",
+                "method": "table",
+                "conf": "3"
+            }
+        }, {
+            "$": {
+                "protocol": "tcp",
+                "portid": "443"
+            },
+            "state": {
+                "state": "closed",
+                "reason": "conn-refused",
+                "reason_ttl": "0"
+            },
+            "service": {
+                "name": "https",
+                "method": "table",
+                "conf": "3"
+            }
+        }],
+        "times": {
+            "srtt": "1812",
+            "rttvar": "2242",
+            "to": "50000"
+        }
+    }],
+    "runstats": {
+        "finished": {
+            "time": "1438608336",
+            "timestr": "Mon Aug  3 15:25:36 2015",
+            "elapsed": "0.05",
+            "summary": "Nmap done at Mon Aug  3 15:25:36 2015; 32 IP addresses (1 host up) scanned in 0.05 seconds",
+            "exit": "success"
+        },
+        "hosts": {
+            "up": "1",
+            "down": "31",
+            "total": "32"
+        }
+    }
+}
 ```
 
-## error handling ##
+## error handling
 The following errors are thrown when invalid configuration options are passed
 to the module and/or when the necessary node.js version is below version v0.11.*
 
-### method ###
+### method
 If you attempt to specify an unkown or unimplemented method, the following error
 is thrown. Allowed methods are `scan` & `discover`.
 
@@ -151,7 +196,7 @@ is thrown. Allowed methods are `scan` & `discover`.
 Method "[missing method]" does not exist, please see node-libnmap API
 ```
 
-### version requirement ###
+### version requirement
 The discover method requires a node.js version > `v0.11` due to the
 `os.networkInterfaces().netmask` property being used to traverse each
 physical/virtual adapter and examing the address space for online hosts.
@@ -160,7 +205,7 @@ physical/virtual adapter and examing the address space for online hosts.
 Requires node.js v0.11.* and above
 ```
 
-### nmap binary ###
+### nmap binary
 If your system does not have the nmap binary installed the following error is
 thrown
 
@@ -168,7 +213,7 @@ thrown
 nmap binary not found, install nmap
 ```
 
-### scanning ranges ###
+### scanning ranges
 When specifying an invalid range to the `scan` method the following error is
 thrown. Valid range types are a single hostname/ipv4 (ipv6 is not yet
 implemented), a CIDR range notation or a range.
@@ -177,7 +222,7 @@ implemented), a CIDR range notation or a range.
 Range must be an array of host(s), examples: ['192.168.2.10', '10.0.2.0/24', '10.0.10.5-20']
 ```
 
-### port range ###
+### port range
 A range of ports may also be specified with the `scan` method, for an invalid
 port specification the following error is thrown.
 
@@ -185,7 +230,7 @@ port specification the following error is thrown.
 Port(s) must match one of the following examples: 512 (single) | 0-65535 (range) | 22-25,80,443,3306 (multiple)
 ```
 
-### ulimit ###
+### ulimit
 If you recieve the `spawn EAGAIN` or `spawn EMFILE` error(s) you have reached
 the max number of `max user processes`. This error is generally thrown if your
 attempting to scan a very large network block.
@@ -202,7 +247,7 @@ $ ulimit -n 65000
 against attacks such as a [fork bombing](http://en.wikipedia.org/wiki/Fork_bomb)
 & [chroot jail breaking](http://www.bpfh.net/simes/computing/chroot-break.html).
 
-## performance ##
+## performance
 A note on performance of nmap scans; the nmap tool already makes efforts to
 utilize parallel processing when multiple processor cores are available.
 
@@ -229,13 +274,13 @@ nmap -sn -oG - 10.0.2.225-255
 The technical details of [Fyodor's](http://insecure.org/fyodor/) optimizations
 can be found @ [insecure.org](http://nmap.org/book/man-performance.html).
 
-## benchmarks ##
+## benchmarks
 The results here are all coming from a virtual environment with limited system
 resources but should give an overall picture of performance of the scans. My VM
 environment is using 8 cores with 4 threads per core given a total returned from
 `require('os').cpus.length` = 32.
 
-### Nmap host discovery ###
+### Nmap host discovery
 ```sh
 $ time nmap -sn -oG - 10.0.2.0/24
 # Nmap 5.51 scan initiated Wed Jan  8 18:54:07 2014 as: nmap -sn -oG - 10.0.2.0/24
@@ -249,7 +294,7 @@ user    0m0.052s
 sys     0m0.080s
 ```
 
-### Nmap host `discover` method using node-libnmap ###
+### Nmap host `discover` method using node-libnmap
 ```javascript
 $ time node test/run.js
 { adapter: 'eth0',
@@ -300,7 +345,7 @@ user    0m0.493s
 sys     0m0.796s
 ```
 
-### Nmap full port scan ###
+### Nmap full port scan
 ```sh
 $ time nmap -T4 -oG - localhost 10.0.2.0/24 192.168.2.0/25
 # Nmap 5.51 scan initiated Sun Jan 26 08:03:18 2014 as: nmap -T4 -oG - localhost 10.0.2.0/24 192.168.2.0/25
@@ -323,7 +368,7 @@ user    0m0.911s
 sys     0m3.315s
 ```
 
-### Nmap host `scan` method using node-libnmap ###
+### Nmap host `scan` method using node-libnmap
 The test case used:
 ```javascript
 var libnmap = require('node-libnmap')
@@ -469,7 +514,7 @@ user    0m13.066s
 sys     0m8.890s
 ```
 
-### Class B network scans ###
+### Class B network scans
 To really test the performance of the module I did several scans of a class B
 network containing a maximum host count of `32766`. Below are the times for
 both scans.
@@ -492,19 +537,19 @@ sys     0m33.950s
 
 Mileage may vary
 
-## contributing ##
+## contributing
 I welcome contributions. Testing, patches, features etc. are appreciated. To
 submit a pull request the following instructions will help.
 
-### fork ###
+### fork
 First fork the project from [github.com](https://github.com/jas-/node-libnmap).
 
-### branch ###
+### branch
 Any contributions you make should be made under a unique branch to avoid
 conflicts. While creating your branch it is recommended you track changes with the latest production
 branch like so: `git checkout -b my-new-feature -t origin/master`
 
-### upstream changes ###
+### upstream changes
 1. To ensure changes are as up to date as possible it is recommended to add an
 upstream branch to rebase any upstream changes like so:
 `git remote add upstream https://github.com/jas-/node-libnmap.git`
@@ -512,5 +557,5 @@ upstream branch to rebase any upstream changes like so:
 2. You will then need to `merge` it to track the `contribute` branch:
 `git fetch upstream`
 
-### pull request ###
+### pull request
 Once you have modified your branch simply create a pull request that I can review and test prior to acceptance.

--- a/examples/nmap-discover.js
+++ b/examples/nmap-discover.js
@@ -1,0 +1,13 @@
+var libnmap = require('../');
+
+libnmap.nmap('discover', function(err, reports) {
+  if (err) throw new Error(err);
+
+  reports.forEach(function (report) {
+    console.log('%s (%s)', report.properties.address, report.adapter);
+
+    report.neighbors.forEach(function (neighbor) {
+      console.log('---> %s', neighbor);
+    });
+  })
+});

--- a/examples/nmap-scan.js
+++ b/examples/nmap-scan.js
@@ -1,0 +1,20 @@
+var ip = require('ip');
+var libnmap = require('../');
+
+// 10.20.30.28 -> 10.20.30.0/25
+var ipRange = [ip.address().split('.').slice(0, 3).join('.') + '.0/25'];
+
+libnmap
+  .nmap('scan', {
+    range: ipRange,
+    ports: '80,443'
+  }, function(err, reports){
+    if (err) throw new Error(err);
+
+    reports.forEach(function (report) {
+      report.host.forEach(function (host) {
+        var ports = host.ports.map(function (port) { return port.$.portid });
+        console.log('%s -> %s; ports: %s', host.address.addr, host.hostnames.name, ports.join(','));
+      });
+    });
+  });

--- a/lib/node-libnmap.js
+++ b/lib/node-libnmap.js
@@ -3,12 +3,15 @@
  * Copyright(c) 2014-2015 Jason Gerfen <jason.gerfen@gmail.com>
  * License: MIT
  */
-var version = 'v0.1.13'
+var pkg = require('../package.json')
+  , version = 'v' + pkg.version
   , fs = require('fs')
   , os = require('os')
+  , xml2js = require('xml2js')
   , async = require('async')
   , ipv6 = require('ipv6').v6
   , proc = require('child_process')
+  , hasbin = require('hasbin')
   , netmask = require('netmask').Netmask
   , nmap = function(method, options, cb) {
 
@@ -19,15 +22,13 @@ var version = 'v0.1.13'
    * @abstract Default set of options
    *
    * @param {String} nmap - Location of nmap binary
-   * @param {String} scripts - Location of nmap lua scripts
    * @param {String} defaults - Default scan options
    * @param {Object} range - Must contain start & end key with value
    * @param {String} ports - Comma separated list of ports to scan
    */
   var defaults = {
-    nmap: '/usr/bin/nmap',
-    scripts: '/usr/bin/nmap/scripts/',
-    flags: '-oG -',
+    nmap: 'nmap',
+    flags: '',
     range: '',
     ports: '',
     threshold: os.cpus().length * 2,
@@ -75,29 +76,39 @@ var version = 'v0.1.13'
       cb = cb || opts;
 
       opts = setup.init(opts);
-      opts.flags = opts.flags + ' -T4';
+      opts.flags = [opts.flags, '-oX -', '-T5'].join(' ');
 
       setup.verify(opts);
       setup.check(opts);
 
       var cmd = false
         , hosts = tools.convert(opts.range)
-        , report = [];
+        , reports = [];
 
       async.mapLimit(hosts, opts.threshold, function(host, callback) {
         opts.range = host;
         cmd = tools.command(opts);
+        var report = [];
         var e = proc.exec(cmd);
 
         e.stdout.on('data', function(chunk) {
-          var result = tools.report(chunk);
-
-          if (result.length > 0)
-            report.push(result);
+          report.push(chunk);
         });
 
         e.stdout.on('end', function() {
-          callback(null, report);
+          var xml = report.join('');
+
+          xml2js.parseString(xml, function (err, json) {
+            if(err) cb(err, null);
+
+            var flattenReport = tools.flattenReport(json);
+
+            if(flattenReport.host) {
+              reports.push(flattenReport);
+            }
+
+            callback(null, reports);
+          });
         });
 
       }, function(err, results) {
@@ -117,7 +128,7 @@ var version = 'v0.1.13'
       cb = cb || opts;
 
       opts = setup.init(opts);
-      opts.flags = opts.flags + ' -sn';
+      opts.flags = opts.flags + ' -oG - -sn';
 
       setup.version();
       setup.check(opts);
@@ -174,8 +185,9 @@ var version = 'v0.1.13'
      */
     version: function() {
       this.interfaces().forEach(function(iface){
-        if (!iface.properties.netmask)
+        if (!iface.properties.netmask) {
           throw new Error('The discover method requires node.js >= v0.11.2');
+        }
       });
     },
 
@@ -188,10 +200,11 @@ var version = 'v0.1.13'
      * @returns {Boolean}
      */
     check: function(opts) {
-      fs.exists(opts.nmap, function(exists) {
-        if (!exists)
+      hasbin('nmap', function (result) {
+        if(!result) {
           throw new Error('The nmap binary was not found. Install nmap');
-      });
+        }
+      })
     },
 
     /**
@@ -236,7 +249,7 @@ var version = 'v0.1.13'
      */
     interfaces: function() {
       var ifaces = require('os').networkInterfaces()
-				, obj = [];
+        , obj = [];
 
       for (var i in ifaces) {
         if (/array|object/.test(ifaces[i])) {
@@ -397,7 +410,7 @@ var version = 'v0.1.13'
           case (validate.perform(tests.IPv4CIDR, host) ||
             validate.perform(tests.IPv6CIDR, host)):
 
-						/* break up the ipv6 into blocks */
+            /* break up the ipv6 into blocks */
 
             cidr = new netmask(host);
 
@@ -495,8 +508,9 @@ var version = 'v0.1.13'
       opts = opts || {};
 
       for (var item in defaults) {
-        if (opts.hasOwnProperty(item))
+        if (opts.hasOwnProperty(item)) {
           defaults[item] = opts[item];
+        }
 
         opts[item] = defaults[item];
       }
@@ -528,51 +542,54 @@ var version = 'v0.1.13'
       return items;
     },
 
-    /**
-     * @function report
-     * @abstract Generates JSON object as report of scan
-     *
-     * @param {String} results - NMAP scan results
-     *
-     * @returns {Array} Array of hosts & services
-     */
-    report: function(results) {
-      var obj = results.split('\n')
-        , tmp = {}
-        , report = [];
 
-      obj.forEach(function(item) {
+    flattenRecusive: function flattenRecusive(report) {
 
-        if (/ports:/i.test(item)) {
-          var details = item.split('\t');
-
-          if (details) {
-            details.forEach(function(detail) {
-
-              if (/host/i.test(detail)) {
-                var host = /host: (.*) \((.*)\)/ig.exec(detail);
-
-                if (host[1])
-                  tmp.ip = host[1];
-
-                if (host[2])
-                  tmp.hostname = host[2];
-              }
-
-              if (/ports/i.test(detail)) {
-                var ports = /ports: (.*)/ig.exec(detail);
-
-                ports = ports[1].split(',');
-                tmp.ports = tools.ports(ports);
-              }
-
-            });
-            report.push(tmp);
+      // isArray
+      if((!!report) && (report.constructor === Array)) {
+        if(report.length !== 1) {
+          var arr = [];
+          for (var i = 0; i < report.length; i++) {
+            arr.push(flattenRecusive(report[i]));
           }
+          return arr;
+        } else {
+          return flattenRecusive(report[0]);
         }
-      });
+        // isObject
+      } else if((!!report) && (report.constructor === Object)) {
+        if(Object.keys(report).length > 1) {
+          var obj = {};
+          
+          for(var key in report) {
+            // prevent flattening for host array
+            if(['host', 'ports'].indexOf(key) !== -1) {
+              if(report[key].length > 1) {
+                var preventArr = [];
+                for (var h = 0; h < report[key].length; h++) {
+                  preventArr.push(flattenRecusive(report[key][h]));
+                }
+                obj[key] = preventArr;
+              } else {
+                obj[key] = [flattenRecusive(report[key])];
+              }
+            } else {
+              obj[key] = flattenRecusive(report[key]);
+            }
+          }
+          
+          return obj;
+        } else {
+          var _key = Object.keys(report)[0];
+          return flattenRecusive(report[_key]);
+        }
+      }
 
       return report;
+    },
+
+    flattenReport: function (report) {
+      return tools.flattenRecusive(report.nmaprun);
     },
 
     /**

--- a/lib/node-libnmap.js
+++ b/lib/node-libnmap.js
@@ -563,6 +563,10 @@ var pkg = require('../package.json')
           
           for(var key in report) {
             // prevent flattening for host array
+            if(key === '$') {
+              continue;
+            }
+
             if(['host', 'ports'].indexOf(key) !== -1) {
               if(report[key].length > 1) {
                 var preventArr = [];

--- a/package.json
+++ b/package.json
@@ -21,16 +21,20 @@
   },
   "scripts": {
     "start": "node index.js",
-    "test": "make test"
+    "test": "./node_modules/.bin/mocha -R spec"
   },
   "dependencies": {
-    "netmask": "~1.0.4",
     "async": "~0.2.10",
-    "ipv6": "~3.1.1"
+    "hasbin": "^1.1.0",
+    "ipv6": "~3.1.1",
+    "netmask": "~1.0.4",
+    "xml2js": "^0.4.9"
   },
   "devDependencies": {
+    "ip": "^0.3.3",
+    "chai": "~1.8.1",
     "mocha": "~1.17.0",
-    "chai": "~1.8.1"
+    "mockery": "^1.4.0"
   },
   "license": "MIT",
   "engine": "node >= v0.11.*"

--- a/test/cp-mocks.js
+++ b/test/cp-mocks.js
@@ -1,0 +1,26 @@
+var fs = require('fs');
+
+var FIXTURE_NMAPRUN_SCAN = fs.readFileSync(__dirname + '/fixtures/nmaprun-scan.xml');
+var FIXTURE_NMAPRUN_DISCOVER = fs.readFileSync(__dirname + '/fixtures/namprun-discover.txt');
+
+var exports = module.exports = {
+  discover: {
+    exec: function (cmd, callback) {
+      if(callback) {
+        callback(null, [FIXTURE_NMAPRUN_DISCOVER.toString('utf8')]);
+      }
+    }
+  },
+  scan: (function () {
+    function on (listener, cb) {
+      if(listener === 'data') {
+        cb(FIXTURE_NMAPRUN_SCAN);
+      }
+      if(listener === 'end') {
+        cb();
+      }
+    }
+
+    return { exec: function (cmd) { return { stdout: { on: on } } } };
+  }())
+}

--- a/test/discover.js
+++ b/test/discover.js
@@ -1,33 +1,29 @@
-/*
- * node-libnmap
- *
- * Copyright 2014-2015 Jason Gerfen
- * All rights reserved.
- *
- * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
- * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
- * SUCH DAMAGE.
- */
+var TIMEOUT = 1024 * 1024;
 
-var libnmap = require('../')
-  , timeout = 1024 * 1024
-  , chai = require('chai')
-  , should = chai.should()
-  , expect = chai.expect
+var chai = require('chai');
+var should = chai.should();
+var expect = chai.expect;
 
-describe('nmap', function(){
+var mockery = require('mockery');
 
-  describe('discovery method', function(){
-    it('validate report', function(done){
-      this.timeout(timeout)
+
+describe('nmap', function() {
+
+  var childProcessMock = require('./cp-mocks.js').discover;
+
+  mockery.enable({
+    warnOnReplace: false,
+    warnOnUnregistered: false,
+    useCleanCache: true
+  });
+
+  mockery.registerMock('child_process', childProcessMock);
+
+  var libnmap = require('../');
+
+  describe('discovery method', function() {
+    it('validate report', function(done) {
+      this.timeout(TIMEOUT)
 
       libnmap.nmap('discover', function(err, report){
         should.not.exist(err)
@@ -59,4 +55,9 @@ describe('nmap', function(){
       })
     })
   })
+
+  after(function () {
+    mockery.deregisterMock('child_process');
+  });
 })
+

--- a/test/fixtures/namprun-discover.txt
+++ b/test/fixtures/namprun-discover.txt
@@ -1,0 +1,6 @@
+# Nmap 6.47 scan initiated Mon Aug  3 13:31:11 2015 as: nmap -oG - -sn 10.10.20.1-63
+Strange error from connect (65):No route to host
+Host: 10.12.18.1 (mock.data)  Status: Up
+Host: 10.12.18.24 (osmc.mock.data)  Status: Up
+Host: 10.12.18.34 (Mock-MBP) Status: Up
+# Nmap done at Mon Aug  3 13:31:15 2015 -- 63 IP addresses (3 hosts up) scanned in 4.43 seconds

--- a/test/fixtures/nmaprun-scan.xml
+++ b/test/fixtures/nmaprun-scan.xml
@@ -1,0 +1,42 @@
+<!DOCTYPE nmaprun>
+<?xml-stylesheet href="file:///usr/local/bin/../share/nmap/nmap.xsl" type="text/xsl"?>
+<!-- Nmap 6.47 scan initiated Mon Aug  3 12:59:38 2015 as: nmap -oX - -T5 -p1-1024 10.11.18.1-32 -->
+<nmaprun scanner="nmap" args="nmap -oX - -T5 -p1-1024 10.11.18.1-32" start="1438599578" startstr="Mon Aug  3 12:59:38 2015" version="6.47" xmloutputversion="1.04">
+<scaninfo type="connect" protocol="tcp" numservices="1024" services="1-1024"/>
+<verbose level="0"/>
+<debugging level="0"/>
+<host starttime="1438599578" endtime="1438599580"><status state="up" reason="syn-ack" reason_ttl="0"/>
+<address addr="10.11.18.1" addrtype="ipv4"/>
+<hostnames>
+<hostname name="mock.data" type="PTR"/>
+</hostnames>
+<ports><extraports state="closed" count="1019">
+<extrareasons reason="conn-refused" count="1019"/>
+</extraports>
+<port protocol="tcp" portid="23"><state state="open" reason="syn-ack" reason_ttl="0"/><service name="telnet" method="table" conf="3"/></port>
+<port protocol="tcp" portid="53"><state state="open" reason="syn-ack" reason_ttl="0"/><service name="domain" method="table" conf="3"/></port>
+<port protocol="tcp" portid="80"><state state="open" reason="syn-ack" reason_ttl="0"/><service name="http" method="table" conf="3"/></port>
+<port protocol="tcp" portid="443"><state state="open" reason="syn-ack" reason_ttl="0"/><service name="https" method="table" conf="3"/></port>
+<port protocol="tcp" portid="1012"><state state="open" reason="syn-ack" reason_ttl="0"/><service name="unknown" method="table" conf="3"/></port>
+</ports>
+<times srtt="18841" rttvar="792" to="50000"/>
+</host>
+<host starttime="1438599578" endtime="1438599581"><status state="up" reason="syn-ack" reason_ttl="0"/>
+<address addr="10.11.18.24" addrtype="ipv4"/>
+<hostnames>
+<hostname name="osmc.mock.data" type="PTR"/>
+</hostnames>
+<ports><extraports state="closed" count="1019">
+<extrareasons reason="conn-refused" count="1019"/>
+</extraports>
+<port protocol="tcp" portid="22"><state state="open" reason="syn-ack" reason_ttl="0"/><service name="ssh" method="table" conf="3"/></port>
+<port protocol="tcp" portid="80"><state state="open" reason="syn-ack" reason_ttl="0"/><service name="http" method="table" conf="3"/></port>
+<port protocol="tcp" portid="111"><state state="open" reason="syn-ack" reason_ttl="0"/><service name="rpcbind" method="table" conf="3"/></port>
+<port protocol="tcp" portid="139"><state state="open" reason="syn-ack" reason_ttl="0"/><service name="netbios-ssn" method="table" conf="3"/></port>
+<port protocol="tcp" portid="445"><state state="open" reason="syn-ack" reason_ttl="0"/><service name="microsoft-ds" method="table" conf="3"/></port>
+</ports>
+<times srtt="13198" rttvar="32" to="50000"/>
+</host>
+<runstats><finished time="1438599581" timestr="Mon Aug  3 12:59:41 2015" elapsed="3.24" summary="Nmap done at Mon Aug  3 12:59:41 2015; 32 IP addresses (2 hosts up) scanned in 3.24 seconds" exit="success"/><hosts up="2" down="30" total="32"/>
+</runstats>
+</nmaprun>

--- a/test/init.js
+++ b/test/init.js
@@ -1,85 +1,45 @@
-/*
- * node-libnmap
- *
- * Copyright 2014-2015 Jason Gerfen
- * All rights reserved.
- *
- * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
- * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
- * SUCH DAMAGE.
- */
+var pkg = require('../package.json');
 
-var version = 'v0.1.13'
-  , usage = 'https://github.com/jas-/node-libnmap'
-  , support = 'https://github.com/jas-/node-libnmap/issues'
-  , license = 'https://github.com/jas-/node-libnmap/blob/master/LICENSE'
-  , legal = 'http://nmap.org/book/man-legal.html'
-  , libnmap = require('../')
-  , chai = require('chai')
-  , should = chai.should()
-  , expect = chai.expect
-  , nmap = libnmap.nmap()
+var chai = require('chai')
+var should = chai.should()
+var expect = chai.expect;
+
+var nmap;
 
 describe('nmap', function(){
 
+  before(function () {
+    nmap = require('../').nmap();
+  })
+
   describe('default method', function(){
-    it('object description', function(done){
 
-      nmap.should.be.a('object')
-      should.exist(nmap.name)
-      should.exist(nmap.version)
-      should.exist(nmap.usage)
-      should.exist(nmap.license)
-      should.exist(nmap.issues)
-      should.exist(nmap.name)
-
-      nmap.nmap.should.be.a('object')
-      should.exist(nmap.nmap.legal)
-
-      done()
+    it('object description', function() {
+      expect(nmap).to.be.a('object')
     })
 
-    it('latest version', function(done){
-
-      expect(nmap.version).to.be.equal(version)
-
-      done()
+    it('latest version', function() {
+      expect(nmap.version).to.be.equal('v' + pkg.version)
     })
 
-    it('usage url', function(done){
-
-      expect(nmap.usage).to.be.equal(usage)
-
-      done()
+    it('usage url', function() {
+      expect(nmap.usage).to.be.equal('https://github.com/jas-/node-libnmap');
     })
 
-    it('support url', function(done){
-
-      expect(nmap.issues).to.be.equal(support)
-
-      done()
+    it('support url', function() {
+      expect(nmap.issues).to.be.equal(pkg.bugs.url);
     })
 
-    it('license url', function(done){
-
-      expect(nmap.license).to.be.equal(license)
-
-      done()
+    it('license url', function() {
+      expect(nmap.license).to.be.equal('https://github.com/jas-/node-libnmap/blob/master/LICENSE');
     })
 
-    it('legal url (nmap)', function(done){
-
-      expect(nmap.nmap.legal).to.be.equal(legal)
-
-      done()
+    it('legal url (nmap)', function() {
+      expect(nmap.nmap.legal).to.be.equal('http://nmap.org/book/man-legal.html')
     })
   })
+
+  after(function () {
+    libnmap = undefined;
+  });
 })

--- a/test/scan.js
+++ b/test/scan.js
@@ -37,7 +37,6 @@ describe('nmap', function() {
 
         reports.should.be.a('array')
 
-        reports[0].$.scanner.should.equal('nmap');
         reports[0].host.should.be.a('array');
         expect(reports[0].host[0].hostnames.name).to.equal('mock.data');
         expect(reports[0].host[0].hostnames.type).to.equal('PTR');


### PR DESCRIPTION
#### Features
- Using the XML Output of `nmap` for the `scan` method
- Remove makefile as test dependency
- Make test working with mocks
- Add examples for `scan` and `discover`