### PR TITLE
Make node-libnmap work on windows systems.

### DIFF
--- a/lib/node-libnmap.js
+++ b/lib/node-libnmap.js
@@ -56,6 +56,7 @@ var version = 'v0.1.13'
       }
     }
     defaults.nmap = directory + "nmap.exe";
+    console.log(defaults);
     defaults.scripts = directory + "scripts/";
   }
 

--- a/lib/node-libnmap.js
+++ b/lib/node-libnmap.js
@@ -32,6 +32,22 @@ var version = 'v0.1.13'
     ports: '',
     threshold: os.cpus().length * 2,
   };
+  
+  /*
+    Some defaults (pathnames) need to be changed on win32.
+    The NMap installer either installes to:
+      C:/Program Files/NMap (32-bit install), or
+      C:/Program Files (x86)/NMap (64-bit install)
+  */
+  if (process.platform === 'win32') {
+    var directory = "C:/Program Files/NMap/";
+    var stats = fs.lstatSync(directory);
+    if (!stats.isDirectory()) {
+      directory = "C:/Program Files (x86)/NMap/";
+    }
+    defaults.nmap = directory + "nmap.exe";
+    defaults.scripts = directory + "scripts/";
+  }
 
   /**
    * @object methods

--- a/lib/node-libnmap.js
+++ b/lib/node-libnmap.js
@@ -40,10 +40,11 @@ var version = 'v0.1.13'
       C:/Program Files (x86)/NMap (64-bit install)
   */
   if (process.platform === 'win32') {
-    var directory = "C:/Program Files/NMap/";
-    var alt = "C:/Program Files (x86)/NMap/";
+    var check = "C:/Program Files/NMap/";
+    var directory = "C:/Program\\ Files/NMap/";
+    var alt = "C:/Program Files\\ (x86)/NMap/";
     try {
-      var stats = fs.lstatSync(directory);
+      var stats = fs.lstatSync(check);
       if (!stats.isDirectory()) {
         directory = alt;
       }

--- a/lib/node-libnmap.js
+++ b/lib/node-libnmap.js
@@ -32,7 +32,7 @@ var version = 'v0.1.13'
     ports: '',
     threshold: os.cpus().length * 2,
   };
-  
+
   /*
     Some defaults (pathnames) need to be changed on win32.
     The NMap installer either installes to:
@@ -41,9 +41,18 @@ var version = 'v0.1.13'
   */
   if (process.platform === 'win32') {
     var directory = "C:/Program Files/NMap/";
-    var stats = fs.lstatSync(directory);
-    if (!stats.isDirectory()) {
-      directory = "C:/Program Files (x86)/NMap/";
+    var alt = "C:/Program Files (x86)/NMap/";
+    try {
+      var stats = fs.lstatSync(directory);
+      if (!stats.isDirectory()) {
+        directory = alt;
+      }
+    } catch (e) {
+      if (e.code === 'ENOENT') {
+        directory = alt;
+      } else {
+        console.error(e);
+      }
     }
     defaults.nmap = directory + "nmap.exe";
     defaults.scripts = directory + "scripts/";

--- a/lib/node-libnmap.js
+++ b/lib/node-libnmap.js
@@ -42,7 +42,7 @@ var version = 'v0.1.13'
   if (process.platform === 'win32') {
     var check = "C:/Program Files/NMap/";
     var directory = "C:/Program\\ Files/NMap/";
-    var alt = "C:/Program Files\\ (x86)/NMap/";
+    var alt = "C:/Program\\ Files\\ (x86)/NMap/";
     try {
       var stats = fs.lstatSync(check);
       if (!stats.isDirectory()) {

--- a/lib/node-libnmap.js
+++ b/lib/node-libnmap.js
@@ -40,23 +40,12 @@ var version = 'v0.1.13'
       C:/Program Files (x86)/Nmap (64-bit install)
   */
   if (process.platform === 'win32') {
-    var check = "C:/Program Files/Nmap/";
-    var directory = "C:/Program\\ Files/Nmap/";
-    var alt = "C:/Program\\ Files\\ (x86)/Nmap/";
-    try {
-      var stats = fs.lstatSync(check);
-      if (!stats.isDirectory()) {
-        directory = alt;
-      }
-    } catch (e) {
-      if (e.code === 'ENOENT') {
-        directory = alt;
-      } else {
-        console.error(e);
-      }
+    var directory = "C:/Program Files/Nmap/";
+    var alt = "C:/Program Files (x86)/Nmap/";
+    if (!fs.existsSync(directory)) {
+      directory = alt;
     }
     defaults.nmap = directory + "nmap.exe";
-    console.log(defaults);
     defaults.scripts = directory + "scripts/";
   }
 
@@ -393,8 +382,8 @@ var version = 'v0.1.13'
         , option = (v6.isValid()) ? ' -6 ' : ' ';
 
       return (!opts.ports) ?
-        opts.nmap + ' ' + opts.flags + option + opts.range :
-        opts.nmap + ' ' + opts.flags + option + ' -p' + opts.ports + ' ' + opts.range;
+        '"' + opts.nmap + '" ' + opts.flags + option + opts.range :
+        '"' + opts.nmap + '" ' + opts.flags + option + ' -p' + opts.ports + ' ' + opts.range;
     },
 
     /**

--- a/lib/node-libnmap.js
+++ b/lib/node-libnmap.js
@@ -36,13 +36,13 @@ var version = 'v0.1.13'
   /*
     Some defaults (pathnames) need to be changed on win32.
     The NMap installer either installes to:
-      C:/Program Files/NMap (32-bit install), or
-      C:/Program Files (x86)/NMap (64-bit install)
+      C:/Program Files/Nmap (32-bit install), or
+      C:/Program Files (x86)/Nmap (64-bit install)
   */
   if (process.platform === 'win32') {
-    var check = "C:/Program Files/NMap/";
-    var directory = "C:/Program\\ Files/NMap/";
-    var alt = "C:/Program\\ Files\\ (x86)/NMap/";
+    var check = "C:/Program Files/Nmap/";
+    var directory = "C:/Program\\ Files/Nmap/";
+    var alt = "C:/Program\\ Files\\ (x86)/Nmap/";
     try {
       var stats = fs.lstatSync(check);
       if (!stats.isDirectory()) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-libnmap",
-  "version": "0.1.13",
+  "version": "0.2.0",
   "description": "Use nmap from node.js",
   "author": "Jason Gerfen <jason.gerfen@gmail.com>",
   "keywords": [


### PR DESCRIPTION
I have modified node-libnmap to detect windows systems and adapt the default NMap path to point to the location to which it is installed by the NMap windows installer.