### PR TITLE
Specified object key names for attributes/char to overide $ and _

### DIFF
--- a/lib/libnmap.js
+++ b/lib/libnmap.js
@@ -127,7 +127,16 @@ var version = 'v0.2.15'
         return cb(null, xml);
 
       try {
-        xml2js.parseString(xml, function parseXML(err, json) {
+
+
+        // Instantiate a parser and specify that we want to override the default ("$") attribute key name.
+        var parserOptions = {
+          attrkey: "item",
+          // "charkey" could be overridden here as well but nmap results don't seem to contain character strings
+        };
+        var xmlParser = new xml2js.Parser(parserOptions);
+
+        xmlParser.parseString(xml, function parseXML(err, json) {
           if(err)
             return cb(new Error(err));
 


### PR DESCRIPTION
... to promote compatibility / storage into mongo db. Before this change, the object returned by the scan could not be directly inserted into mongo without heavy modification. 
