### PR TITLE
Stop -oX - flag being added if it already exists

### DIFF
--- a/lib/libnmap.js
+++ b/lib/libnmap.js
@@ -78,7 +78,8 @@ var version = 'v0.2.28'
       opts.called = called;
 
       /* Ensure we can parse the report */
-      opts.flags.push('-oX -');
+      if (opts.flags.indexOf('-oX -') === -1)
+        opts.flags.push('-oX -');
 
       validation.init(opts, function(err, result) {
         if (err)


### PR DESCRIPTION
Fixes a minor issue I was seeing where the '-oX -' flag was being added multiple times.