### PR TITLE
Add option to run nmap commands with sudo

### DIFF
--- a/lib/libnmap.js
+++ b/lib/libnmap.js
@@ -32,6 +32,7 @@ var version = 'v0.2.29'
    * @param {Array} flags - Array of flags for .spawn()
    * @param {Boolean} udp - Perform a scan using the UDP protocol
    * @param {Boolean} json - JSON object as output, false produces XML
+   * @param {Boolean} sudo - Run nmap with sudo
    */
   var defaults = {
     nmap:       'nmap',
@@ -45,7 +46,8 @@ var version = 'v0.2.29'
       '-T4',    // Scan optimization
     ],
     udp:        false,
-    json:       true
+    json:       true,
+    sudo:       false
   };
 
   /**
@@ -282,14 +284,15 @@ var version = 'v0.2.29'
      */
     command: function(opts, block) {
       var flags = opts.flags.join(' ')
+        , sudo = opts.sudo ? 'sudo ' : ''
         , ip = new v6.Address(block)
         , ipv6 = (ip.isValid()) ? ' -6 ' : ' '
         , proto = (opts.udp) ? ' -sU' : ' '
         , to = '--host-timeout='+opts.timeout+'s ';
 
       return (opts.ports) ?
-        opts.nmap+proto+' '+to+flags+ipv6+'-p'+opts.ports+' '+block :
-        opts.nmap+proto+' '+to+flags+ipv6+block;
+        sudo+opts.nmap+proto+' '+to+flags+ipv6+'-p'+opts.ports+' '+block :
+        sudo+opts.nmap+proto+' '+to+flags+ipv6+block;
     },
 
     /**


### PR DESCRIPTION
Some nmap commands need to be run as root. Rather than running a whole node app as root, we can just escalate privileges for specific nmap commands.

I've added 'sudo' to the opts available. If true, it will run the command with sudo. It defaults to false.