### PR TITLE
Fixed typo error in example

### DIFF
--- a/examples/accuracy.js
+++ b/examples/accuracy.js
@@ -8,7 +8,7 @@
 
 const nmap = require('../');
 const opts = {
-  timeout: 900, // 900s = 10m and increases the reliability of scan results
+  timeout: 900, // 900s = 15m and increases the reliability of scan results
   flags: [
     '-T0', // Paranoid scan type; very slow but accurate
     '--max-retries 10', // Don't give up on slow responding hosts

--- a/examples/timeout.js
+++ b/examples/timeout.js
@@ -8,7 +8,7 @@
 
 const nmap = require('../');
 const opts = {
-  timeout: 900, // 900s = 10m and increases the reliability of scan results
+  timeout: 900, // 900s = 15m and increases the reliability of scan results
   range: ['scanme.nmap.org', '192.168.0.0/26']
 };
 


### PR DESCRIPTION
Fixed typo error. 900 seconds was earlier commented as 10 minutes instead of 15 minutes.