### PR TITLE
fix invalid target in scans

### DIFF
--- a/lib/classes/tools.js
+++ b/lib/classes/tools.js
@@ -158,7 +158,7 @@ class tools extends emitter {
    */
   command(opts, block) {
     const flags = opts.flags.join(' ');
-    const proto = (opts.udp) ? ' -sU' : ' ';
+    const proto = (opts.udp) ? ' -sU' : '';
     const to = `--host-timeout=${opts.timeout}s `;
     const ipv6 = (validation.test(validation.patterns.IPv6, block)) ?
       ' -6 ' : ' ';


### PR DESCRIPTION
An extra space is causing an invalid target in every scan result. This fix is to remove the extra space from the args passed to nmap.

**Details to reproduce:**
Run a scan such as the code below:
```
const opts = {
  range: ['scanme.nmap.org']
};

nmap.scan(opts, function(err, report) {
  console.log(JSON.stringify(report, null, 2));
});
```

The output, contains an invalid target entry with empty specification.
```
"target": [
  {
    "item": {
        "specification": "",
        "status": "skipped",
        "reason": "invalid"
      }
    }
]
```
And there are two spaces in the args between the ports and the host
```
"args": "nmap --host-timeout=120s -T4 -oX - -p1-1024  scanme.nmap.org",
```