### PR TITLE
Disable defaults

### DIFF
--- a/examples/no-defaults.js
+++ b/examples/no-defaults.js
@@ -1,0 +1,22 @@
+/*!
+ * libnmap
+ * Copyright(c) 2021 Evandro Brandão <evandroaribel@gmail.com>
+ * License: MIT
+ */
+
+'use strict'
+
+const nmap = require('../');
+const opts = {
+  range: ['scanme.nmap.org', '127.0.0.1'],
+  noDefaults: true
+};
+
+
+nmap.scan(opts, function(err, report) {
+  if (err) throw new Error(err);
+
+  for (let item in report) {
+    console.log(JSON.stringify(report[item], null, 2));
+  }
+});

--- a/lib/classes/tools.js
+++ b/lib/classes/tools.js
@@ -158,14 +158,13 @@ class tools extends emitter {
    */
   command(opts, block) {
     const flags = opts.flags.join(' ');
-    const proto = (opts.udp) ? ' -sU' : ' ';
-    const to = `--host-timeout=${opts.timeout}s `;
+    const proto = (opts.udp) ? ' -sU ' : ' ';
+    const to = opts.timeout ? `--host-timeout=${opts.timeout}s ` :'';
     const ipv6 = (validation.test(validation.patterns.IPv6, block)) ?
       ' -6 ' : ' ';
-
     return (opts.ports) ?
-      `${opts.nmap+proto} ${to}${flags}${ipv6}-p${opts.ports} ${block}` :
-      `${opts.nmap+proto} ${to}${flags}${ipv6}${block}`;
+      `${opts.nmap+proto}${to}${flags}${ipv6}-p${opts.ports} ${block}` :
+      `${opts.nmap+proto}${to}${flags}${ipv6}${block}`;
   }
 
 
@@ -197,6 +196,11 @@ class tools extends emitter {
     const ranges = [];
     const called = caller.get()[1].getFunctionName();
 
+    /** Remove defaults options if user disabled it (flags, ports, timeout) */
+    if(opts.noDefaults) {
+      const {ports, timeout, ...defaultsRest} = defaults;
+      defaults = {...defaultsRest, flags: []};
+    }
     /* Override 'defaults.flags' array with 'opts.flags' (prevents merge) */
     if (/array/.test(typeof opts.flags))
       defaults.flags = opts.flags;

--- a/lib/classes/validation.js
+++ b/lib/classes/validation.js
@@ -100,7 +100,6 @@ class validation {
     const scope = this;
     let errors = [];
     let result;
-
     scope.exists(opts.nmap, (result) => {
       if (!result) {
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   },
   "scripts": {
     "start": "node index.js",
-    "test": "./node_modules/.bin/mocha -R spec"
+    "test": "./node_modules/.bin/mocha -R spec",
+    "test:no-defaults": "./node_modules/.bin/mocha test/no-defaults.spec.js"
   },
   "dependencies": {
     "async": "^2.6.3",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "libnmap",
+  "name": "libnmap-xtr",
   "version": "v0.4.19",
   "description": "libnmap for node.js",
-  "author": "Jason Gerfen <jason.gerfen@gmail.com>",
+  "author": "Jason Gerfen <jason.gerfen@gmail.com>, Evandro Brandão <evandroaribel@gmail.com>",
   "keywords": [
     "nmap",
     "libnmap",
@@ -23,15 +23,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/jas-/node-libnmap.git"
-  },
-  "bugs": {
-    "url": "https://github.com/jas-/node-libnmap/issues"
+    "url": "https://github.com/kingaribel/node-libnmap.git"
   },
   "scripts": {
     "start": "node index.js",
-    "test": "./node_modules/.bin/mocha -R spec",
-    "test:no-defaults": "./node_modules/.bin/mocha test/no-defaults.spec.js"
+    "test": "./node_modules/.bin/mocha "
   },
   "dependencies": {
     "async": "^2.6.3",

--- a/test/no-defaults.spec.js
+++ b/test/no-defaults.spec.js
@@ -1,0 +1,50 @@
+/*!
+ * libnmap
+ * Copyright(c) 2013-2019 Jason Gerfen <jason.gerfen@gmail.com>
+ * License: MIT
+ */
+
+'use strict'
+
+const nmap = require('../');
+const timeout = 1024 * 1024 * 3;
+const chai = require('chai');
+const should = chai.should();
+const expect = chai.expect;
+const opts = {
+  range: [
+    '127.0.0.1',
+    'scanme.nmap.org',
+    '::1'
+  ],
+  noDefaults: true
+};
+
+
+describe('scan method', function () {
+
+  context('reporting', function () {
+    it('json', function (done) {
+      this.timeout(timeout);
+
+      nmap.scan(opts, function (err, report) {
+        should.not.exist(err);
+
+        report.should.be.a('object');
+        done();
+      });
+    });
+
+    it('xml', function (done) {
+      this.timeout(timeout);
+      opts.json = false;
+
+      nmap.scan(opts, function (err, report) {
+        should.not.exist(err);
+
+        report.should.be.a('object');
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
Added an option to disable the default options "flags, ports and timeouts" called "noDefaults", it's checked in the code if this option has value "true", if it does remove "ports and timeouts", the option "flags" is cleared because cannot be deleted because of checking the "-oX -" option. I did this because I implemented a solution and the client asked me not to have standard commands, and this was the easiest way I could think of comparing to developing my solution when one already exists.