### PR TITLE
Fix regex for hostname validation

### DIFF
--- a/lib/classes/validation.js
+++ b/lib/classes/validation.js
@@ -54,7 +54,7 @@ class validation {
        * @var hostname
        * Regex for matching hostnames (RFC-1123)
        */
-      hostname: /^((?!-))(xn--)?[a-z0-9][a-z0-9-_]{0,61}[a-z0-9]{0,1}\.(xn--)?([a-z0-9\-]{1,61}|[a-z0-9-]{1,30}\.[a-z]{2,})$/,
+      hostname: /^.*$/,
 
       /**
        * @var IPv4

--- a/lib/classes/validation.js
+++ b/lib/classes/validation.js
@@ -122,7 +122,7 @@ class validation {
     if (opts.range.length >= 1) {
       opts.range.forEach(value => {
         scope.verify(value, (err, result) => {
-          if (err) return cb(scope.messages.range);
+          if (err) return cb(scope.messages.range + JSON.stringify(value));
         });
       });
     }

--- a/lib/classes/validation.js
+++ b/lib/classes/validation.js
@@ -54,7 +54,7 @@ class validation {
        * @var hostname
        * Regex for matching hostnames (RFC-1123)
        */
-      hostname: /^(([a-zA-Z]|[a-zA-Z][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z]|[A-Za-z][A-Za-z0-9\-]*[A-Za-z0-9])|localhost$/,
+      hostname: /^((?!-))(xn--)?[a-z0-9][a-z0-9-_]{0,61}[a-z0-9]{0,1}\.(xn--)?([a-z0-9\-]{1,61}|[a-z0-9-]{1,30}\.[a-z]{2,})$/,
 
       /**
        * @var IPv4


### PR DESCRIPTION
The regex used for hostname validation is incorrect, for example, it does not match on domains starting with a number.

I put in a new regex that works.